### PR TITLE
Update wasm-bindgen to 0.2.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,9 @@ license = "MIT"
 
 [dependencies]
 pulldown-cmark = "0.8.0"
-wasm-bindgen = "0.2.68"
+wasm-bindgen = "0.2.70"
 js-sys = "0.3.45"
 console_error_panic_hook = "0.1.6"
 
 [lib]
 crate-type = ["cdylib"]
-
-[package.metadata.wasm-pack.profile.release]
-# Workaround for https://github.com/rustwasm/wasm-pack/issues/886, which
-# started happening with wasm-bindgen 0.2.66.
-wasm-opt = ["-O", "--enable-mutable-globals"]


### PR DESCRIPTION
With the new version of wasm-bindgen, it will no longer emit mutable globals, so the workaround to enable them in wasm-opt isn't needed.
これは解決します ：https://github.com/yumetodo/markdown_img_url_editor_rust/issues/2